### PR TITLE
Hotfix for tasklists

### DIFF
--- a/resources/views/admin/tasklists/show.blade.php
+++ b/resources/views/admin/tasklists/show.blade.php
@@ -33,6 +33,8 @@
                 getTaskListId() {
                     let path = window.location.pathname
                     this.url = /\d/.exec(path)
+                    console.log('Path: ' + path)
+                    console.log('URL: ' + this.url)
                 },
                 getTasks() {
                     axios.get(route('api.tasklists.show', this.url))


### PR DESCRIPTION
## Issues with viewing tasklists
* Added `console.log()` as output to display the path and url